### PR TITLE
[PATCH 2/2] sun7i-a20-bananapi-r1.dts: initialize ahci 5v power

### DIFF
--- a/arch/arm/Makefile
+++ b/arch/arm/Makefile
@@ -13,7 +13,13 @@
 # Ensure linker flags are correct
 LDFLAGS		:=
 
-LDFLAGS_vmlinux	:=-p --no-undefined -X --pic-veneer
+GCCVERSIONISGTE5 := $(shell expr `$(HOSTCC) -dumpversion | cut -f1 -d.` \>= 5)
+ifeq  "$(GCCVERSIONISGTE5)" "1"
+LDFLAGS_vmlinux :=-p --no-undefined -X
+else
+LDFLAGS_vmlinux :=-p --no-undefined -X --pic-veneer
+endif
+
 ifeq ($(CONFIG_CPU_ENDIAN_BE8),y)
 LDFLAGS_vmlinux	+= --be8
 LDFLAGS_MODULE	+= --be8

--- a/arch/arm/boot/Makefile
+++ b/arch/arm/boot/Makefile
@@ -82,7 +82,6 @@ $(obj)/uImage:	$(obj)/zImage FORCE
 
 $(obj)/bootp/bootp: $(obj)/zImage initrd FORCE
 	$(Q)$(MAKE) $(build)=$(obj)/bootp $@
-	@:
 
 $(obj)/bootpImage: $(obj)/bootp/bootp FORCE
 	$(call if_changed,objcopy)

--- a/arch/arm/boot/bootp/Makefile
+++ b/arch/arm/boot/bootp/Makefile
@@ -17,7 +17,6 @@ targets	:= bootp init.o kernel.o initrd.o
 # Note that bootp.lds picks up kernel.o and initrd.o
 $(obj)/bootp:	$(src)/bootp.lds $(addprefix $(obj)/,init.o kernel.o initrd.o) FORCE
 	$(call if_changed,ld)
-	@:
 
 # kernel.o and initrd.o includes a binary image using
 # .incbin, a dependency which is not tracked automatically

--- a/arch/arm/boot/dts/sun7i-a20-bananapi-r1.dts
+++ b/arch/arm/boot/dts/sun7i-a20-bananapi-r1.dts
@@ -89,6 +89,7 @@
 };
 
 &ahci {
+	target-supply = <&reg_ahci_5v>;
 	status = "okay";
 };
 
@@ -180,6 +181,10 @@
 		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
 		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
 	};
+};
+
+&reg_ahci_5v {
+	status = "okay";
 };
 
 &reg_usb1_vbus {

--- a/drivers/net/phy/swconfig_leds.c
+++ b/drivers/net/phy/swconfig_leds.c
@@ -14,6 +14,7 @@
 
 #include <linux/leds.h>
 #include <linux/ctype.h>
+#include <linux/slab.h>
 #include <linux/device.h>
 #include <linux/workqueue.h>
 


### PR DESCRIPTION
This is part 2 of patches that address problems with SATA device power; most likely including the hard drive issues with power work-arounds for USB power.  I had severe issues running a rootfs on SSD with the default device tree files, but no issues whatsoever with this patch.  Tested over several days compiling kernels and toolchains on the device while powered over microusb with no more problems.  First pull request is part 1 u-boot patch.
